### PR TITLE
Fix performance issus with async_to_sync decorator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
     install_requires=[
         'pyri-common',
         'pyri-device-manager',
-        'robotraconteur',
-        "asgiref"
+        'robotraconteur'
     ],
     tests_require=['pytest','pytest-asyncio'],
     extras_require={

--- a/src/pyri/devices_states/pyri_devices_states.py
+++ b/src/pyri/devices_states/pyri_devices_states.py
@@ -98,7 +98,7 @@ class PyriDevicesStatesService:
             await asyncio.sleep(1)
             while True:
                 await self._do_refresh_devices(0)
-                await asyncio.sleep(10)
+                await asyncio.sleep(1)
         except:
             traceback.print_exc()
             raise


### PR DESCRIPTION
The async_to_sync decorator from asgiref was being used to repeatedly call functions in the service loop. This was a significant performance bottleneck, and was the cause of high cpu usage. Replacing with a single asyncio thread with tasks corrected the problem.